### PR TITLE
Typo in Z20 polynomial space for first kind Nédélec on D-cubes

### DIFF
--- a/elements/nedelec1.def
+++ b/elements/nedelec1.def
@@ -62,8 +62,8 @@ reference-elements:
 polynomial-set:
   triangle: poly[k-1]^d && <k>[\left\{\boldsymbol{p}\in{{tpoly[k]^d}}\middle|\boldsymbol{p}({{x}})\cdot {{x}}=0\right\}]
   tetrahedron: poly[k-1]^d && <k>[\left\{\boldsymbol{p}\in{{tpoly[k]^d}}\middle|\boldsymbol{p}({{x}})\cdot {{x}}=0\right\}]
-  quadrilateral: qoly[k-1]^d && <k>[\left\{\boldsymbol{q}\in{{tqoly[k]}}\middle|\boldsymbol{q}(\boldsymbol{x})\cdot x_i\boldsymbol{e}_i\in{{qoly[k]}}\text{ for }i=1,\dots,d\right\}]
-  hexahedron: qoly[k-1]^d && <k>[\left\{\boldsymbol{q}\in{{tqoly[k]}}\middle|\boldsymbol{q}(\boldsymbol{x})\cdot x_i\boldsymbol{e}_i\in{{qoly[k]}}\text{ for }i=1,\dots,d\right\}]
+  quadrilateral: qoly[k-1]^d && <k>[\left\{\boldsymbol{q}\in{{tqoly[k]^d}}\middle|\boldsymbol{q}(\boldsymbol{x})\cdot x_i\boldsymbol{e}_i\in{{qoly[k]}}\text{ for }i=1,\dots,d\right\}]
+  hexahedron: qoly[k-1]^d && <k>[\left\{\boldsymbol{q}\in{{tqoly[k]^d}}\middle|\boldsymbol{q}(\boldsymbol{x})\cdot x_i\boldsymbol{e}_i\in{{qoly[k]}}\text{ for }i=1,\dots,d\right\}]
 dofs:
   edges: tangent integral moments with (lagrange,k-1)
   faces:


### PR DESCRIPTION
Typo in the definition of Z20 space for first Kind nedelec on rectangles / hexa, this space is a vector valued polynomial space, so a subset of \tqoly[k]^d and not \tqoly[k].
