### PR TITLE
Fix typo in the de Rham page

### DIFF
--- a/pages/de-rham.md
+++ b/pages/de-rham.md
@@ -16,7 +16,7 @@ H^{k-1}
 $$
 
 A set of four finite elements \(\mathcal{V}_0\) to \(\mathcal{V}_3\) forms 
-a discrete de Rham complex if the following commitative diagram holds,
+a discrete de Rham complex if the following commutative diagram holds,
 where \(I_0\) to \(I_3\) are interpolations into \(\mathcal{V}_0\) to \(\mathcal{V}_3\).
 (The commutative diagram holds if following different arrow combinations to the same destination will give the same result.)
 $$


### PR DESCRIPTION
Hi,

I have also noticed that the Lagrange pages are broken, but I'm not sure if the issue is in DefElement or Symfem. Check for instance https://defelement.org/elements/examples/quadrilateral-lagrange-equispaced-3.html (but there are more), where it now seems we're using a hierarchical description instead of the usual interpolation at equidistant nodes.

Cheers,
-Nuno
