### PR TITLE
Add Ferrite.jl code examples

### DIFF
--- a/defelement/implementations/core.py
+++ b/defelement/implementations/core.py
@@ -265,7 +265,7 @@ class Implementation:
 
             assert degree is not None
             code += "\n\n"
-            if language == "python":
+            if language in ["python", "julia"]:
                 code += "# "
             elif language in ["rust", "c++", "c"]:
                 code += "// "

--- a/defelement/implementations/ferrite.py
+++ b/defelement/implementations/ferrite.py
@@ -1,0 +1,107 @@
+"""Implementation in Ferrite.jl."""
+
+import re
+import typing
+
+from defelement.element import Element
+from defelement.implementations.core import Implementation, NotImplementedOnReference
+
+# DefElement reference cell names mapped to the Ferrite.jl reference shapes
+reference_shapes = {
+    "interval": "RefLine",
+    "triangle": "RefTriangle",
+    "quadrilateral": "RefQuadrilateral",
+    "tetrahedron": "RefTetrahedron",
+    "hexahedron": "RefHexahedron",
+    "prism": "RefPrism",
+    "pyramid": "RefPyramid",
+}
+
+# The registry file that Julia's package manager resolves Ferrite's versions from
+versions_url = (
+    "https://raw.githubusercontent.com/JuliaRegistries/General/master/F/Ferrite/Versions.toml"
+)
+
+
+class FerriteImplementation(Implementation):
+    """Implementation in Ferrite.jl."""
+
+    @classmethod
+    def format(cls, string: str, params: dict[str, typing.Any]) -> str:
+        """Format implementation string."""
+        out = string
+        for p, v in params.items():
+            if p == "vdim":
+                out += f"^{v}"
+            else:
+                raise ValueError(f"Unexpected parameter: {p}")
+        return out
+
+    @classmethod
+    def example_import(cls, language: str) -> str:
+        """Get imports to include at start of example."""
+        if language != "julia":
+            raise ValueError(f"Unsupported language: {language}")
+        return "using Ferrite"
+
+    @classmethod
+    def single_example(
+        cls,
+        name: str,
+        reference: str,
+        degree: int,
+        params: dict[str, str],
+        language: str,
+        element: Element,
+        example: str,
+    ) -> str:
+        """Generate code for a single example."""
+        if language != "julia":
+            raise ValueError(f"Unsupported language: {language}")
+        if reference not in reference_shapes:
+            raise NotImplementedOnReference()
+        out = f"ip = {name}{{{reference_shapes[reference]}, {degree}}}()"
+        for p, v in params.items():
+            if p == "vdim":
+                out += f"^{v}"
+            else:
+                raise ValueError(f"Unexpected parameter: {p}")
+        return out
+
+    @classmethod
+    def install(cls, language: str) -> str | None:
+        """Get the command(s) to install this implementation."""
+        if language == "julia":
+            return "julia -e 'using Pkg; Pkg.add(\"Ferrite\")'"
+        return None
+
+    @classmethod
+    def version(cls) -> str:
+        """Get the version number of this implementation."""
+        import requests
+
+        # Ferrite is not registered on PyPI, so the latest release is read from the entries of
+        # Julia's General registry, which are of the form `["1.2.3"]`
+        versions = re.findall(
+            r'^\["([0-9]+(?:\.[0-9]+)*)"\]', requests.get(versions_url).text, re.MULTILINE
+        )
+        return max(versions, key=lambda v: tuple(int(i) for i in v.split(".")))
+
+    @classmethod
+    def notes(cls, element: Element) -> list[str]:
+        """Return a list of notes to include for the implementation of this element."""
+        if element.filename == "serendipity":
+            return [
+                (
+                    "Ferrite.jl uses point evaluations at the midpoints of the edges of the cell "
+                    "in place of the integral moments used in DefElement's definition of this "
+                    "element. Its basis functions therefore differ from the ones shown here, "
+                    "although they span the same space."
+                )
+            ]
+        return []
+
+    id = "ferrite"
+    name = "Ferrite.jl"
+    url = "https://github.com/Ferrite-FEM/Ferrite.jl"
+    languages = ("julia",)

--- a/defelement/languages.py
+++ b/defelement/languages.py
@@ -8,6 +8,28 @@ from webtools.code_markup import cpp_highlight, python_highlight, rust_highlight
 from defelement.implementations import Implementation
 
 
+def julia_highlight(code: str) -> str:
+    """Highlight comments in a Julia snippet and convert it to HTML.
+
+    webtools does not provide a Julia highlighter. The snippets are short enough that
+    keyword highlighting adds little, so only comments are highlighted, using the same
+    color that webtools uses.
+
+    Args:
+        code: Julia snippet
+
+    Returns:
+        Snippet with comments highlighted
+    """
+    out = []
+    for line in code.replace(" ", "&nbsp;").split("\n"):
+        if "#" in line:
+            line, comment = line.split("#", 1)
+            line += f"<span style='color:#FF8800'>#{comment}</span>"
+        out.append(line)
+    return "<br />".join(out)
+
+
 class Language:
     """A programming language."""
 
@@ -99,6 +121,18 @@ class Cpp(Language):
 
     id = "cpp"
     name = "C++"
+
+
+class Julia(Language):
+    """Julia."""
+
+    @classmethod
+    def highlight(cls, code: str) -> str:
+        """Add code highlighting."""
+        return julia_highlight(code)
+
+    id = "julia"
+    name = "Julia"
 
 
 this = sys.modules[__name__]

--- a/elements/brezzi-douglas-marini.def
+++ b/elements/brezzi-douglas-marini.def
@@ -54,6 +54,9 @@ implementations:
     legendre: BDM
   fiat:
     legendre: BrezziDouglasMarini variant=integral
+  ferrite:
+    lagrange:
+      triangle: BrezziDouglasMarini DEGREES=1
 examples:
   - triangle,1,lagrange
   - triangle,2,lagrange

--- a/elements/bubble-enriched-lagrange.def
+++ b/elements/bubble-enriched-lagrange.def
@@ -18,6 +18,8 @@ polynomial-set:
   triangle: poly[k] && <k+2>[\left\{p\in {{poly[k]}}\middle|p=0\text{ on the boundary}\right\}]
 implementations:
   symfem: bubble enriched Lagrange
+  ferrite:
+    triangle: BubbleEnrichedLagrange DEGREES=1
 examples:
   - triangle,1
   - triangle,2

--- a/elements/crouzeix-raviart.def
+++ b/elements/crouzeix-raviart.def
@@ -63,6 +63,11 @@ implementations:
   fiat:
     triangle: CrouzeixRaviart
     tetrahedron: CrouzeixRaviart
+  ferrite:
+    triangle: CrouzeixRaviart
+    tetrahedron: CrouzeixRaviart
+    quadrilateral: RannacherTurek
+    hexahedron: RannacherTurek
 examples:
   - triangle,1
   - tetrahedron,1

--- a/elements/discontinuous-lagrange.def
+++ b/elements/discontinuous-lagrange.def
@@ -171,6 +171,15 @@ implementations:
       quadrilateral: Lagrange continuity=Discontinuous
       tetrahedron: Lagrange continuity=Discontinuous
       hexahedron: Lagrange continuity=Discontinuous
+  ferrite:
+    equispaced:
+      interval: DiscontinuousLagrange DEGREES=0:3
+      triangle: DiscontinuousLagrange DEGREES=0:6
+      tetrahedron: DiscontinuousLagrange DEGREES=0:5
+      quadrilateral: DiscontinuousLagrange DEGREES=0:4
+      hexahedron: DiscontinuousLagrange DEGREES=0:4
+      prism: DiscontinuousLagrange DEGREES=0:3
+      pyramid: DiscontinuousLagrange DEGREES=0:3
 examples:
   - interval,0,equispaced
   - interval,1,equispaced

--- a/elements/lagrange.def
+++ b/elements/lagrange.def
@@ -166,6 +166,15 @@ implementations:
   simplefem:
     equispaced:
       triangle: lagrange_element DEGREEMAP=(k+1)*(k+2)//2
+  ferrite:
+    equispaced:
+      interval: Lagrange DEGREES=1,2
+      triangle: Lagrange DEGREES=1:6
+      tetrahedron: Lagrange DEGREES=1:5
+      quadrilateral: Lagrange DEGREES=1:4
+      hexahedron: Lagrange DEGREES=1:4
+      prism: Lagrange DEGREES=1,2
+      pyramid: Lagrange DEGREES=1,2
 examples:
   - interval,1,equispaced
   - interval,2,equispaced

--- a/elements/nedelec1.def
+++ b/elements/nedelec1.def
@@ -124,6 +124,12 @@ implementations:
       tetrahedron: NedelecFirstKind DEGREEMAP=k+1
       quadrilateral: NedelecFirstKind DEGREEMAP=k+1
       hexahedron: NedelecFirstKind DEGREEMAP=k+1
+  ferrite:
+    lagrange:
+      triangle: Nedelec DEGREEMAP=k+1 DEGREES=0,1
+      tetrahedron: Nedelec DEGREEMAP=k+1 DEGREES=0
+      quadrilateral: Nedelec DEGREEMAP=k+1 DEGREES=0
+      hexahedron: Nedelec DEGREEMAP=k+1 DEGREES=0
 examples:
   - triangle,0,lagrange
   - triangle,1,lagrange

--- a/elements/raviart-thomas.def
+++ b/elements/raviart-thomas.def
@@ -101,6 +101,12 @@ implementations:
     legendre:
       triangle: RaviartThomas variant=integral DEGREEMAP=k+1
       tetrahedron: RaviartThomas variant=integral DEGREEMAP=k+1
+  ferrite:
+    lagrange:
+      triangle: RaviartThomas DEGREEMAP=k+1 DEGREES=0,1
+      tetrahedron: RaviartThomas DEGREEMAP=k+1 DEGREES=0
+      quadrilateral: RaviartThomas DEGREEMAP=k+1 DEGREES=0
+      hexahedron: RaviartThomas DEGREEMAP=k+1 DEGREES=0
 examples:
   - triangle,0,lagrange
   - triangle,1,lagrange

--- a/elements/serendipity.def
+++ b/elements/serendipity.def
@@ -48,6 +48,9 @@ implementations:
   basix: serendipity lagrange_variant=equispaced dpc_variant=simplex_equispaced
   basix.ufl: serendipity lagrange_variant=equispaced dpc_variant=simplex_equispaced
   fiat: Serendipity
+  ferrite:
+    quadrilateral: Serendipity DEGREES=2
+    hexahedron: Serendipity DEGREES=2
 examples:
   - interval,1
   - interval,2

--- a/elements/vector-bubble-enriched-lagrange.def
+++ b/elements/vector-bubble-enriched-lagrange.def
@@ -18,6 +18,8 @@ polynomial-set:
   triangle: poly[k]^d && <k+2>[\left\{p\in {{poly[k]}}\middle|p=0\text{ on the boundary}\right\}]^d
 implementations:
   symfem: bubble enriched vector Lagrange
+  ferrite:
+    triangle: BubbleEnrichedLagrange vdim=2 DEGREES=1
 examples:
   - triangle,1
   - triangle,2

--- a/elements/vector-lagrange.def
+++ b/elements/vector-lagrange.def
@@ -30,6 +30,9 @@ degree: polynomial-subdegree
 implementations:
   symfem: vector Lagrange
   basix.ufl: P shape=(dim,) lagrange_variant=equispaced
+  ferrite:
+    triangle: Lagrange vdim=2 DEGREES=1:6
+    tetrahedron: Lagrange vdim=3 DEGREES=1:5
 examples:
   - triangle,1
   - triangle,2

--- a/elements/vector-q.def
+++ b/elements/vector-q.def
@@ -35,6 +35,9 @@ polynomial-set:
 implementations:
   symfem: vector Q
   basix.ufl: P lagrange_variant=equispaced shape=(dim,)
+  ferrite:
+    quadrilateral: Lagrange vdim=2 DEGREES=1:4
+    hexahedron: Lagrange vdim=3 DEGREES=1:4
 examples:
   - quadrilateral,1
   - quadrilateral,2


### PR DESCRIPTION
Add Ferrite.jl (https://github.com/Ferrite-FEM/Ferrite.jl) to the list of implementations, with Julia code snippets for creating each supported interpolation.

New implementation class (defelement/implementations/ferrite.py):
 - Snippets construct interpolations as `Name{RefShape, order}()`, with DefElement cell names mapped to Ferrite reference shapes (e.g. interval -> RefLine). Vectorized interpolations use the `^vdim` syntax via a `vdim` parameter in the .def files.
 - Since Ferrite is not on PyPI, version() resolves the latest release from the Versions.toml registry file of Julia's General registry.

Julia language support:
 - New Julia entry in defelement/languages.py. webtools has no Julia highlighter and the snippets are short, so a minimal local formatter highlights comments only (same color webtools uses).
 - Use "#" as the comment prefix for Julia example headers in defelement/implementations/core.py.

Elements covered (all interpolations in Ferrite v1.6.0), with DEGREES restrictions matching the orders implemented in Ferrite:
 - Lagrange and discontinuous Lagrange (equispaced variant) on all seven reference cells
 - Crouzeix-Raviart (CrouzeixRaviart on simplices, RannacherTurek on quadrilateral/hexahedron)
 - bubble enriched Lagrange (triangle)
 - serendipity (Serendipity, degree 2 on quadrilateral/hexahedron)
 - Raviart-Thomas and Nedelec first kind (Lagrange variant, with DEGREEMAP=k+1 since Ferrite's lowest order is 1 where DefElement's degree is 0)
 - Brezzi-Douglas-Marini (Lagrange variant, triangle degree 1)
 - vector Lagrange, vector Q and vector bubble enriched Lagrange via VectorizedInterpolation (`ip^vdim`)

Note on serendipity: Ferrite uses point evaluations at edge midpoints (classical Q8/Q20) where DefElement defines the edge DOFs as integral moments, giving a different basis for the same space. This is flagged with an implementation note on the element page.

Generated by 🤖 and reviewed by me.