### PR TITLE
Pin Julia to 1.11 in CI so juliacall can find Ferrite

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -147,7 +147,8 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
-          version: "1"
+          # juliacall only supports Julia < 1.12 for now
+          version: "1.11"
 
       - name: Install implementations
         run: |

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
-          version: "1"
+          # juliacall only supports Julia < 1.12 for now
+          version: "1.11"
 
       - name: Install implementations
         run: |


### PR DESCRIPTION
`juliacall` only supports Julia < 1.12 for now (OpenSSL version conflict between Julia and Python). With `setup-julia` resolving `"1"` to `1.12`, `juliapkg` downloaded its own Julia 1.11 with an empty environment, so `using Ferrite` failed and every Ferrite verification case was marked as failing.
